### PR TITLE
feat: Ensure target directory exists before writing secure file

### DIFF
--- a/buildtask/index.js
+++ b/buildtask/index.js
@@ -2,6 +2,7 @@ const tl = require('vsts-task-lib/task');
 const vsts = require('vso-node-api');
 const fs = require('fs');
 const path = require('path');
+const shell = require("shelljs")
 
 const serverUrl = tl.getVariable('System.TeamFoundationCollectionUri');
 const restAPI = new vsts.WebApi(
@@ -19,6 +20,10 @@ console.log(`Downloading secureFileId=${secureFileId} to destFile=${destFile}`)
 
 restAPI.getTaskAgentApi().downloadSecureFile(tl.getVariable('SYSTEM.TEAMPROJECT'), secureFileId, tl.getSecureFileTicket(secureFileId), false)
 	.then((file) => {
+		const destDirectory = path.dirname(destFile)
+		if(!fs.existsSync(destDirectory)) {
+			shell.mkdir('-p', destDirectory)
+		}
 		file.pipe(fs.createWriteStream(destFile))
 			.on('finish', () => {
 				console.log(`Wrote secure file to ${destFile}`)

--- a/buildtask/package.json
+++ b/buildtask/package.json
@@ -7,6 +7,9 @@
     "upload": "tfx build tasks upload --task-path ."
   },
   "dependencies": {
+    "fs": "0.0.1-security",
+    "path": "^0.12.7",
+    "shelljs": "^0.7.8",
     "vso-node-api": "^6.2.3-preview",
     "vsts-task-lib": "^2.0.5"
   },


### PR DESCRIPTION
This commit just adds target directory creation if it does not already exist.
support recursive path.